### PR TITLE
Expand glob patterns and handle other shell expansions in flutter test commands

### DIFF
--- a/command_builder.go
+++ b/command_builder.go
@@ -43,7 +43,11 @@ func (r realCommandBuilder) ensureToJunitAvailable(cfg config) {
 }
 
 func (r realCommandBuilder) buildTestCmd(additionalParams []string) commandWrapper {
-	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+strings.Join(additionalParams, " "))}
+	params := strings.Join(additionalParams, " ")
+	if params != "" {
+		params = " " + params
+	}
+	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+params)}
 	//return realCommandWrapper{cmd: exec.Command("flutter", append([]string{"test", "--machine"}, additionalParams...)...)}
 }
 

--- a/command_builder.go
+++ b/command_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -42,7 +43,8 @@ func (r realCommandBuilder) ensureToJunitAvailable(cfg config) {
 }
 
 func (r realCommandBuilder) buildTestCmd(additionalParams []string) commandWrapper {
-	return realCommandWrapper{cmd: exec.Command("flutter", append([]string{"test", "--machine"}, additionalParams...)...)}
+	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+strings.Join(additionalParams, " "))}
+	//return realCommandWrapper{cmd: exec.Command("flutter", append([]string{"test", "--machine"}, additionalParams...)...)}
 }
 
 func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {

--- a/command_builder.go
+++ b/command_builder.go
@@ -44,7 +44,7 @@ func (r realCommandBuilder) ensureToJunitAvailable(cfg config) {
 
 func (r realCommandBuilder) buildTestCmd(additionalParams []string) commandWrapper {
 	params := buildParamString(additionalParams)
-	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+params)}
+	return realCommandWrapper{cmd: exec.Command("/bin/zsh", "-c", "flutter test --machine"+params)}
 }
 
 func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
@@ -54,7 +54,7 @@ func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
 
 func (r realCommandBuilder) buildCoverageCmd(additionalParams []string) commandWrapper {
 	params := buildParamString(additionalParams)
-	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --coverage"+params)}
+	return realCommandWrapper{cmd: exec.Command("/bin/zsh", "-c", "flutter test --coverage"+params)}
 }
 
 func buildParamString(additionalParams []string) string {

--- a/command_builder.go
+++ b/command_builder.go
@@ -43,12 +43,16 @@ func (r realCommandBuilder) ensureToJunitAvailable(cfg config) {
 }
 
 func (r realCommandBuilder) buildTestCmd(additionalParams []string) commandWrapper {
+	params := buildParamString(additionalParams)
+	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+params)}
+}
+
+func buildParamString(additionalParams []string) string {
 	params := strings.Join(additionalParams, " ")
 	if params != "" {
 		params = " " + params
 	}
-	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+params)}
-	//return realCommandWrapper{cmd: exec.Command("flutter", append([]string{"test", "--machine"}, additionalParams...)...)}
+	return params
 }
 
 func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
@@ -57,5 +61,6 @@ func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
 }
 
 func (r realCommandBuilder) buildCoverageCmd(additionalParams []string) commandWrapper {
-	return realCommandWrapper{cmd: exec.Command("flutter", append([]string{"test", "--coverage"}, additionalParams...)...)}
+	params := buildParamString(additionalParams)
+	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --coverage"+params)}
 }

--- a/command_builder.go
+++ b/command_builder.go
@@ -47,14 +47,6 @@ func (r realCommandBuilder) buildTestCmd(additionalParams []string) commandWrapp
 	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --machine"+params)}
 }
 
-func buildParamString(additionalParams []string) string {
-	params := strings.Join(additionalParams, " ")
-	if params != "" {
-		params = " " + params
-	}
-	return params
-}
-
 func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
 	r.ensureToJunitAvailable(cfg)
 	return realCommandWrapper{cmd: exec.Command("tojunit", append([]string{"--output", testResultFileName})...)}
@@ -63,4 +55,12 @@ func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
 func (r realCommandBuilder) buildCoverageCmd(additionalParams []string) commandWrapper {
 	params := buildParamString(additionalParams)
 	return realCommandWrapper{cmd: exec.Command("/bin/sh", "-c", "flutter test --coverage"+params)}
+}
+
+func buildParamString(additionalParams []string) string {
+	params := strings.Join(additionalParams, " ")
+	if params != "" {
+		params = " " + params
+	}
+	return params
 }

--- a/step.yml
+++ b/step.yml
@@ -40,6 +40,12 @@ is_requires_admin_user: true
 is_always_run: false
 is_skippable: false
 
+deps:
+  brew:
+    - name: zsh
+  apt_get:
+    - name: zsh
+
 toolkit:
   go:
     package_name: github.com/bitrise-steplib/bitrise-step-flutter-test


### PR DESCRIPTION
### Checklist

- [✅ ] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Globs is not being respected for flutter test run. This is a [behaviour](https://golang.org/pkg/os/exec/) of the Golang `exec` command.

Resolves: #3

### Changes

* Call the flutter test command through shell so globs will be expanded

### Investigation details

### Decisions

* Calling the commands via shell will help the commands executing in the same manner as when they are executed locally in shell.
