### PR TITLE
Making the tab with the test result on bitrise.io use custom name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `project_location` | The root dir of your Flutter project. | required | `$BITRISE_SOURCE_DIR` |
 | `bitrise_test_result_dir` | Root directory for all test results created by the Bitrise CLI | required | `$BITRISE_TEST_RESULT_DIR` |
+| `bitrise_test_result_name` | Name of the created test result collection |  | `Flutter test results` |
 | `generate_code_coverage_files` | In case of `generate_code_coverage_files: "yes"` `flutter test` gets `--coverage` passed | required | `false` |
 | `additional_params` | The flags from this input field are appended to the `flutter test` command. |  |  |
 | `tests_path_pattern` | The pattern from this input field is expanded and fed to the `flutter test` command.   Both * and ** glob patterns are supported. For example, `lib/**/*_test.dart`. |  |  |

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ type config struct {
 	TestsPathPattern          string `env:"tests_path_pattern"`
 	ProjectLocation           string `env:"project_location,dir"`
 	TestResultsDir            string `env:"bitrise_test_result_dir,dir"`
+	TestResultsName           string `env:"bitrise_test_result_name"`
 	GenerateCodeCoverageFiles bool   `env:"generate_code_coverage_files,opt[yes,no]"`
 }
 

--- a/step.yml
+++ b/step.yml
@@ -55,6 +55,10 @@ inputs:
     description: Root directory for all test results created by the Bitrise CLI
     is_required: true
     is_dont_change_value: true
+- bitrise_test_result_name: Flutter test results
+  opts:
+    title: Name of created test results collection
+    is_required: false
 - generate_code_coverage_files: "no"
   opts:
     title: Generate code coverage files?

--- a/test_exporter.go
+++ b/test_exporter.go
@@ -13,7 +13,6 @@ import (
 )
 
 const (
-	testName               = "Flutter test results"
 	testResultJSONFileName = "flutter_json_test_results.json"
 	coverageFileName       = "flutter_coverage_lcov.info"
 	coverageRelativePath   = "./coverage/lcov.info"
@@ -43,7 +42,7 @@ func (r realTestExporter) exportDeployPath(testResultDeployPath string) {
 
 func (r realTestExporter) exportTestResultsToResultPath(cfg config, testResultPath string) {
 	exporter := testresultexport.NewExporter(cfg.TestResultsDir)
-	if err := exporter.ExportTest(testName, testResultPath); err != nil {
+	if err := exporter.ExportTest(cfg.TestResultsName, testResultPath); err != nil {
 		r.interrupt.failWithMessage("Export outputs: failed to export test result: %s", err)
 	}
 }


### PR DESCRIPTION
### Checklist
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context
To enable a custom name, useful if one uses the bitrise-step-flutter-test more than once in a workflow.

### Changes

### Investigation details

### Decisions
