### PR TITLE
Test command fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Performs any test in a Flutter project.
 <summary>Description</summary>
 
 
-If you have tests in your repository, and selected `yes` when prompted during app creation, the primary Workflow will include the **Flutter Test** Step by default. 
+If you have tests in your repository, and selected `yes` when prompted during app creation, the primary Workflow will include the **Flutter Test** Step by default.
 If you add tests to your app later, add the **Flutter Test** Step to your Workflow manually. The Step runs the `flutter test` command with the specified flags. To check the available flags, open a command line interface on your own machine and run `flutter test --help`.
 
 ### Configuring the Step
@@ -17,11 +17,9 @@ If you add tests to your app later, add the **Flutter Test** Step to your Workfl
 3. You can append additional flags to the default `flutter test` command in the **Additional parameters** field.
 4. Select 'yes' in the **Generate code coverage files** input to get detailed analysis of your code.
 
-
 ### Troubleshooting
-Make sure the **Project Location** input of the Flutter Test Step is correct. 
+Make sure the **Project Location** input of the Flutter Test Step is correct.
 The default value is the Environment Variable (Env Var) created for your Flutter project’s location.
-
 
 ### Useful links
 - [Getting started with Flutter](https://devcenter.bitrise.io/getting-started/getting-started-with-flutter-apps/)
@@ -34,7 +32,7 @@ The default value is the Environment Variable (Env Var) created for your Flutter
 
 ## 🧩 Get started
 
-Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/steps/adding-steps-to-a-workflow.html).
 
 You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
@@ -47,9 +45,9 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `project_location` | The root dir of your Flutter project. | required | `$BITRISE_SOURCE_DIR` |
 | `bitrise_test_result_dir` | Root directory for all test results created by the Bitrise CLI | required | `$BITRISE_TEST_RESULT_DIR` |
-| `generate_code_coverage_files` | In case of `generate_code_coverage_files: "yes"` `flutter test` gets `--coverage` passed | required | `false` |
+| `generate_code_coverage_files` | In case of `generate_code_coverage_files: "yes"` `flutter test` gets `--coverage` passed | required | `no` |
 | `additional_params` | The flags from this input field are appended to the `flutter test` command. |  |  |
-| `tests_path_pattern` | The pattern from this input field is expanded and fed to the `flutter test` command.   Both * and ** glob patterns are supported. For example, `lib/**/*_test.dart`. |  |  |
+| `tests_path_pattern` | The pattern from this input field is expanded and fed to the `flutter test` command. Both * and ** glob patterns are supported. For example, `lib/**/*_test.dart`. |  |  |
 </details>
 
 <details>
@@ -65,9 +63,8 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 
 We welcome [pull requests](https://github.com/bitrise-steplib/bitrise-step-flutter-test/pulls) and [issues](https://github.com/bitrise-steplib/bitrise-step-flutter-test/issues) against this repository.
 
-For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://docs.bitrise.io/en/bitrise-ci/bitrise-cli/running-your-first-local-build-with-the-cli.html).
 
 Learn more about developing steps:
 
-- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
-- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)
+- [Create your own step](https://docs.bitrise.io/en/bitrise-ci/workflows-and-pipelines/developing-your-own-bitrise-step/developing-a-new-step.html)

--- a/command_builder.go
+++ b/command_builder.go
@@ -20,23 +20,26 @@ type realCommandBuilder struct {
 }
 
 func (r realCommandBuilder) ensureToJunitAvailable(cfg config) {
-	if _, err := exec.LookPath("tojunit"); err != nil {
-		log.Infof("Command `tojunit` not found, installing...")
-		junitInstallCmd := command.New("flutter", []string{"pub", "global", "activate", "junitreport"}...).
-			SetStdout(os.Stdout).
-			SetStderr(os.Stderr).
-			SetDir(cfg.ProjectLocation)
+	// Always (re)activate junitreport to ensure the compiled binary and lock file
+	// are valid for the current Dart SDK version. A pre-installed tojunit binary
+	// compiled with a different Dart version causes "Can't load Kernel binary"
+	// errors at runtime; a stale lock file (e.g. a transitive dep was bumped in
+	// the pub cache) triggers exit-65 from dart pub. Both are cured by reactivating.
+	log.Infof("Activating `tojunit`...")
+	junitInstallCmd := command.New("dart", []string{"pub", "global", "activate", "--overwrite", "junitreport"}...).
+		SetStdout(os.Stdout).
+		SetStderr(os.Stderr).
+		SetDir(cfg.ProjectLocation)
 
-		fmt.Println()
-		log.Donef(fmt.Sprintf("$ %s", junitInstallCmd.PrintableCommandArgs()))
-		fmt.Println()
+	fmt.Println()
+	log.Donef(fmt.Sprintf("$ %s", junitInstallCmd.PrintableCommandArgs()))
+	fmt.Println()
 
-		if err := junitInstallCmd.Run(); err != nil {
-			if errorutil.IsExitStatusError(err) {
-				r.interrupt.failWithMessage("Install dependencies: command `tojunit` failed to install: %s", err)
-			}
-			r.interrupt.failWithMessage("Install dependencies: failed to run command `tojunit`: %s", err)
+	if err := junitInstallCmd.Run(); err != nil {
+		if errorutil.IsExitStatusError(err) {
+			r.interrupt.failWithMessage("Install dependencies: command `tojunit` failed to install: %s", err)
 		}
+		r.interrupt.failWithMessage("Install dependencies: failed to run command `tojunit`: %s", err)
 	}
 }
 

--- a/command_builder.go
+++ b/command_builder.go
@@ -55,5 +55,7 @@ func (r realCommandBuilder) buildTestCmd(generateCoverage bool, additionalParams
 
 func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
 	r.ensureToJunitAvailable(cfg)
-	return realCommandWrapper{cmd: exec.Command("tojunit", []string{"--output", testResultFileName}...)}
+	// Use "dart pub global run" instead of invoking tojunit by name so that the
+	// executable is found even when $HOME/.pub-cache/bin is not on $PATH (Linux).
+	return realCommandWrapper{cmd: exec.Command("dart", []string{"pub", "global", "run", "junitreport:tojunit", "--output", testResultFileName}...)}
 }

--- a/test_executor.go
+++ b/test_executor.go
@@ -55,18 +55,27 @@ func (r realTestExecutor) executeTest(cfg config, additionalParams []string) (by
 		r.interrupt.failWithMessage("Run: converting test results to junit format failed: %s", err)
 	}
 
-	if err := testCmd.wait(); err != nil {
+	// Wait for testCmd concurrently and close pw when done so junitCmd receives EOF.
+	// This prevents a deadlock where junitCmd exits early, pw.Write() blocks because
+	// pr is no longer being read, and testCmd.Wait() never returns.
+	testErrCh := make(chan error, 1)
+	go func() {
+		testErrCh <- testCmd.wait()
+		pw.Close()
+	}()
+
+	junitErr := junitCmd.wait()
+	pr.Close() // unblocks pw.Write() if junitCmd exited before testCmd finished
+
+	if junitErr != nil {
+		r.interrupt.failWithMessage("Run: completing conversion command failed: %s", junitErr)
+	}
+
+	if err := <-testErrCh; err != nil {
 		log.Errorf("Run: completing test command failed: %s", err)
 		testExecutionFailed = true
 	}
 
-	if err := pw.Close(); err != nil {
-		r.interrupt.failWithMessage("Run: closing pipe failed: %s", err)
-	}
-
-	if err := junitCmd.wait(); err != nil {
-		r.interrupt.failWithMessage("Run: completing conversion command failed: %s", err)
-	}
 	return jsonBuffer, testExecutionFailed
 }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

Fix pipe deadlock and stale `tojunit` activation.

**What changed**

- `test_executor.go` — goroutine deadlock fix

`testCmd.Wait()` would block forever if `junitCmd` exited early (crash or failure). The stdout-copy goroutine started by `exec.Cmd` would block on `pw.Write()` because nobody was reading from `pr` anymore, and `Wait()` can't return until all its goroutines finish.

Fix: `testCmd.wait()` now runs in a background goroutine that closes `pw` when done (signalling EOF to `junitCmd`). `pr.Close()` is called after `junitCmd.wait()` returns to unblock any pending `pw.Write()` calls if `junitCmd` exited before `testCmd` finished writing.

- `command_builder.go` — stale `tojunit` activation fix

`ensureToJunitAvailable` only checked whether `tojunit` was present in `PATH`. A pre-installed binary compiled with a different Dart SDK version causes `Can't load Kernel binary: Invalid kernel binary format version` at runtime. A stale lock file (e.g. a transitive dependency bumped in the pub cache) causes `dart pub` to exit with code 65, printing `The current activation of junitreport cannot resolve to the same set of dependencies`.

Fix: always re-activate via `dart pub global activate --overwrite junitreport`, removing the PATH-only guard. `--overwrite` forces re-compilation for the current SDK and refreshes the lock file. Activation is fast (a few seconds) when already up to date.

`tojunit` is now invoked via `dart pub global run junitreport:tojunit` instead of by name. On Linux, `dart pub global activate` installs executables into `$HOME/.pub-cache/bin` which is not on `$PATH` by default, causing `exec: "tojunit": executable file not found in $PATH`. Using `dart pub global run` bypasses the PATH lookup entirely.