### PR TITLE
Show human-readable Flutter test output (SSW-3088)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ If you add tests to your app later, add the **Flutter Test** Step to your Workfl
 3. You can append additional flags to the default `flutter test` command in the **Additional parameters** field.
 4. Select 'yes' in the **Generate code coverage files** input to get detailed analysis of your code.
 
+### Test output in the build log
+On Flutter 3.10 and newer the Step prints the normal, human-readable `flutter test` output to the build log, and you can control its verbosity with a `--reporter` flag (for example `--reporter expanded`) in the **Additional parameters** field. On older Flutter versions the log falls back to the raw machine JSON stream. The machine-readable JSON needed for the JUnit test report and the `BITRISE_FLUTTER_TESTRESULT_PATH` output is collected separately, so it does not affect what you see in the log. Do not pass `--file-reporter` in **Additional parameters** — the Step manages it internally.
+
 ### Troubleshooting
 Make sure the **Project Location** input of the Flutter Test Step is correct.
 The default value is the Environment Variable (Env Var) created for your Flutter project’s location.
@@ -46,7 +49,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | `project_location` | The root dir of your Flutter project. | required | `$BITRISE_SOURCE_DIR` |
 | `bitrise_test_result_dir` | Root directory for all test results created by the Bitrise CLI | required | `$BITRISE_TEST_RESULT_DIR` |
 | `generate_code_coverage_files` | In case of `generate_code_coverage_files: "yes"` `flutter test` gets `--coverage` passed | required | `no` |
-| `additional_params` | The flags from this input field are appended to the `flutter test` command. |  |  |
+| `additional_params` | The flags from this input field are appended to the `flutter test` command.  For example, pass `--reporter expanded` to get more detailed, human-readable test output in the build log (Flutter 3.10+). Do not pass `--file-reporter`; the Step sets it up internally. |  |  |
 | `tests_path_pattern` | The pattern from this input field is expanded and fed to the `flutter test` command. Both * and ** glob patterns are supported. For example, `lib/**/*_test.dart`. |  |  |
 </details>
 

--- a/command_builder.go
+++ b/command_builder.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -11,8 +12,11 @@ import (
 )
 
 type commandBuilder interface {
-	buildTestCmd(generateCoverage bool, additionalParams []string) commandWrapper
-	buildJunitCmd(cfg config) commandWrapper
+	supportsFileReporter() bool
+	buildTestCmd(generateCoverage bool, fileReporterPath string, additionalParams []string) commandWrapper
+	buildJunitCmd(cfg config, jsonReportPath string) commandWrapper
+	buildLegacyTestCmd(generateCoverage bool, additionalParams []string) commandWrapper
+	buildLegacyJunitCmd(cfg config) commandWrapper
 }
 
 type realCommandBuilder struct {
@@ -43,7 +47,47 @@ func (r realCommandBuilder) ensureToJunitAvailable(cfg config) {
 	}
 }
 
-func (r realCommandBuilder) buildTestCmd(generateCoverage bool, additionalParams []string) commandWrapper {
+// supportsFileReporter reports whether the installed `flutter test` accepts the
+// --file-reporter flag. It was added in Flutter 3.10; on older versions the step
+// falls back to piping `flutter test --machine` into tojunit. We probe the actual
+// `flutter test --help` output rather than parsing versions so custom channels and
+// forks are handled correctly. On any error we assume it is unsupported.
+func (r realCommandBuilder) supportsFileReporter() bool {
+	out, err := exec.Command("flutter", "test", "--help").CombinedOutput()
+	if err != nil {
+		log.Warnf("Could not determine whether `flutter test` supports --file-reporter (%s); falling back to --machine.", err)
+		return false
+	}
+	return strings.Contains(string(out), "--file-reporter")
+}
+
+// buildTestCmd builds the modern test command. It writes the machine-readable JSON to
+// a file via --file-reporter (instead of --machine) so that stdout keeps the normal,
+// human-readable reporter output. With --reporter unset, Flutter auto-selects a
+// CI-friendly reporter (expanded on non-TTY, github on GitHub Actions); users can
+// still override it through additionalParams.
+func (r realCommandBuilder) buildTestCmd(generateCoverage bool, fileReporterPath string, additionalParams []string) commandWrapper {
+	params := []string{"test", "--file-reporter=json:" + fileReporterPath}
+	if generateCoverage {
+		params = append(params, "--coverage")
+	}
+	params = append(params, additionalParams...)
+
+	return realCommandWrapper{cmd: exec.Command("flutter", params...)}
+}
+
+// buildJunitCmd converts the flutter test JSON report at jsonReportPath into JUnit XML.
+func (r realCommandBuilder) buildJunitCmd(cfg config, jsonReportPath string) commandWrapper {
+	r.ensureToJunitAvailable(cfg)
+	// Use "dart pub global run" instead of invoking tojunit by name so that the
+	// executable is found even when $HOME/.pub-cache/bin is not on $PATH (Linux).
+	// tojunit reads the JSON from --input and writes the JUnit XML to --output.
+	return realCommandWrapper{cmd: exec.Command("dart", []string{"pub", "global", "run", "junitreport:tojunit", "--input", jsonReportPath, "--output", testResultFileName}...)}
+}
+
+// buildLegacyTestCmd builds the test command for Flutter versions without --file-reporter
+// (< 3.10): `flutter test --machine`, whose JSON stdout is piped straight into tojunit.
+func (r realCommandBuilder) buildLegacyTestCmd(generateCoverage bool, additionalParams []string) commandWrapper {
 	params := []string{"test", "--machine"}
 	if generateCoverage {
 		params = append(params, "--coverage")
@@ -53,7 +97,8 @@ func (r realCommandBuilder) buildTestCmd(generateCoverage bool, additionalParams
 	return realCommandWrapper{cmd: exec.Command("flutter", params...)}
 }
 
-func (r realCommandBuilder) buildJunitCmd(cfg config) commandWrapper {
+// buildLegacyJunitCmd converts the flutter test JSON read from stdin into JUnit XML.
+func (r realCommandBuilder) buildLegacyJunitCmd(cfg config) commandWrapper {
 	r.ensureToJunitAvailable(cfg)
 	// Use "dart pub global run" instead of invoking tojunit by name so that the
 	// executable is found even when $HOME/.pub-cache/bin is not on $PATH (Linux).

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,11 +1,17 @@
 format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
+# Flutter is installed through Bitrise's built-in mise integration (the `tools` field),
+# which puts `flutter` and `dart` on $PATH for every step in the build.
+# Pinned to 3.7.1 because Flutter 3.10 brings Dart 3.0, which the sample app is not compatible with yet.
+# (This also exercises the Step's pre-3.10 --machine fallback path end to end.)
+tools:
+  flutter: 3.7.1
+
 app:
   envs:
   - SAMPLE_APP_URL: https://github.com/bitrise-io/Bitrise-Flutter-Sample.git
   - SAMPLE_APP_BRANCH: main
-  - FLUTTER_VERSION: 3.7.1  # Flutter 3.10 brings Dart 3.0, this sample app is not compatible with that yet
   - ORIGIN_SOURCE_DIR: $BITRISE_SOURCE_DIR
   - PROJECT_LOCATION: $BITRISE_SOURCE_DIR/_tmp
   - GENERATE_CODE_COVERAGE_FILES: "no"
@@ -63,9 +69,6 @@ workflows:
         - clone_into_dir: $BITRISE_SOURCE_DIR
         - repository_url: $SAMPLE_APP_URL
         - branch: $SAMPLE_APP_BRANCH
-    - flutter-installer:
-        inputs:
-        - version: $FLUTTER_VERSION
     - path::./:
         title: Execute step
         inputs:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -38,6 +38,30 @@ workflows:
     after_run:
     - _common
 
+  # Exercises the modern --file-reporter path (Flutter >= 3.10). The shared sample app
+  # is pinned to Dart < 3.0, so this workflow uses the sample's `dart-3` branch and
+  # overrides the Flutter version to 3.10+ via workflow-level `tools`, reusing _common.
+  test_file_reporter_flutter_3_10_plus:
+    envs:
+    - SAMPLE_APP_BRANCH: dart-3
+    title: Run on Flutter 3.10+ (human-readable --file-reporter path)
+    tools:
+      flutter: 3.32.1
+    after_run:
+    - _common
+    steps:
+    - script:
+        title: Assert this Flutter supports --file-reporter
+        description: |-
+          Guards the purpose of this workflow: if the `tools` override did not apply
+          (or a future Flutter drops the flag), the Step would silently fall back to
+          the legacy --machine path and this workflow would pass without covering it.
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            flutter test --help | grep -q -- '--file-reporter'
+
   _common:
     after_run:
     - _assert_output
@@ -93,10 +117,10 @@ workflows:
             fi
 
             echo "Checking for json test report data at $BITRISE_FLUTTER_TESTRESULT_PATH"
-            if [ -f "$BITRISE_FLUTTER_TESTRESULT_PATH" ]; then
-              echo "JSON report data exists."
+            if [ -s "$BITRISE_FLUTTER_TESTRESULT_PATH" ]; then
+              echo "JSON report data exists and is non-empty."
             else
-              echo "JSON report data does not exist."
+              echo "JSON report data is missing or empty."
               exit 1
             fi
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitrise-steplib/bitrise-step-flutter-test
 
-go 1.16
+go 1.18
 
 require (
 	github.com/bitrise-io/go-steputils v1.0.1
@@ -8,4 +8,10 @@ require (
 	github.com/bmatcuk/doublestar/v3 v3.0.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/main_mock.go
+++ b/main_mock.go
@@ -95,17 +95,33 @@ func (t testWrapperExecutor) exportTestResults(cfg config, b bytes.Buffer) {
 }
 
 type testCommandBuilder struct {
-	testFails bool
+	testFails             bool
+	fileReporterSupported bool
 }
 
-func (t testCommandBuilder) buildTestCmd(generateCoverage bool, additionalParams []string) commandWrapper {
+func (t testCommandBuilder) supportsFileReporter() bool {
+	return t.fileReporterSupported
+}
+
+func (t testCommandBuilder) buildTestCmd(generateCoverage bool, fileReporterPath string, additionalParams []string) commandWrapper {
 	if t.testFails {
 		return failingCmd()
 	}
 	return successCmd()
 }
 
-func (t testCommandBuilder) buildJunitCmd(config) commandWrapper {
+func (t testCommandBuilder) buildJunitCmd(config, string) commandWrapper {
+	return successCmd()
+}
+
+func (t testCommandBuilder) buildLegacyTestCmd(generateCoverage bool, additionalParams []string) commandWrapper {
+	if t.testFails {
+		return failingCmd()
+	}
+	return successCmd()
+}
+
+func (t testCommandBuilder) buildLegacyJunitCmd(config) commandWrapper {
 	return successCmd()
 }
 

--- a/main_mock.go
+++ b/main_mock.go
@@ -133,6 +133,14 @@ func setupFailingUnitTestsExecutor(interrupt interrupt, testResult *testResult) 
 	}, testResult: testResult}
 }
 
+func setupFailingFileReporterExecutor(interrupt interrupt, testResult *testResult) {
+	test = testWrapperExecutor{realTestExecutor: realTestExecutor{
+		interrupt:      interrupt,
+		commandBuilder: testCommandBuilder{testFails: true, fileReporterSupported: true},
+		testExporter:   mockTestExporter{testResult: testResult},
+	}, testResult: testResult}
+}
+
 type mockTestExporter struct {
 	testResult *testResult
 }

--- a/main_test.go
+++ b/main_test.go
@@ -2,10 +2,42 @@ package main
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestBuildTestCmdUsesFileReporterNotMachine(t *testing.T) {
+	builder := realCommandBuilder{}
+
+	cmd := builder.buildTestCmd(false, "/tmp/report.json", []string{"--reporter", "expanded"})
+	args := cmd.toModel().PrintableCommandArgs()
+
+	// --machine must be absent: it forces the JSON reporter and hides human-readable output.
+	assert.False(t, strings.Contains(args, "--machine"), "expected --machine to be absent, got: %s", args)
+	// The JSON is written to a file instead, leaving stdout for the human-readable reporter.
+	assert.True(t, strings.Contains(args, "--file-reporter=json:/tmp/report.json"), "expected --file-reporter, got: %s", args)
+	// A user-supplied reporter flag is passed through and now actually takes effect.
+	assert.True(t, strings.Contains(args, "expanded"), "expected additional params to be appended, got: %s", args)
+}
+
+func TestHasFileReporterArg(t *testing.T) {
+	tests := []struct {
+		name   string
+		params []string
+		want   bool
+	}{
+		{"absent", []string{"--reporter", "expanded"}, false},
+		{"equals form", []string{"--file-reporter=json:/tmp/r.json"}, true},
+		{"space form", []string{"--file-reporter", "json:/tmp/r.json"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, hasFileReporterArg(tt.params))
+		})
+	}
+}
 
 func TestResultsExportedWhenExecutionFails(t *testing.T) {
 	// Arrange

--- a/main_test.go
+++ b/main_test.go
@@ -57,6 +57,25 @@ func TestResultsExportedWhenExecutionFails(t *testing.T) {
 	assert.Equal(t, true, result.stepFailed)
 }
 
+func TestResultsExportedWhenExecutionFailsOnFileReporterPath(t *testing.T) {
+	// Arrange
+	result := testResult{}
+	mi := mockInterrupt{testResult: &result}
+	ir = mi
+	parser = mockParser{}
+	setupFailingFileReporterExecutor(ir, &result)
+
+	// Act
+	main()
+
+	// Assert: even on the modern --file-reporter path, a failing test run still
+	// exports results and marks the step failed, without aborting mid-run.
+	assert.Equal(t, true, result.testResultsExported)
+	assert.Equal(t, true, result.coverageExported)
+	assert.Equal(t, "", result.failedMessage)
+	assert.Equal(t, true, result.stepFailed)
+}
+
 func TestCoverageExportedWhenExecutionFails(t *testing.T) {
 	// Arrange
 	result := testResult{}

--- a/step.yml
+++ b/step.yml
@@ -13,6 +13,9 @@ description: |-
   3. You can append additional flags to the default `flutter test` command in the **Additional parameters** field.
   4. Select 'yes' in the **Generate code coverage files** input to get detailed analysis of your code.
 
+  ### Test output in the build log
+  On Flutter 3.10 and newer the Step prints the normal, human-readable `flutter test` output to the build log, and you can control its verbosity with a `--reporter` flag (for example `--reporter expanded`) in the **Additional parameters** field. On older Flutter versions the log falls back to the raw machine JSON stream. The machine-readable JSON needed for the JUnit test report and the `BITRISE_FLUTTER_TESTRESULT_PATH` output is collected separately, so it does not affect what you see in the log. Do not pass `--file-reporter` in **Additional parameters** — the Step manages it internally.
+
   ### Troubleshooting
   Make sure the **Project Location** input of the Flutter Test Step is correct.
   The default value is the Environment Variable (Env Var) created for your Flutter project’s location.
@@ -69,7 +72,10 @@ inputs:
   opts:
     title: Additional parameters
     summary: The flags from this input field are appended to the `flutter test` command.
-    description: The flags from this input field are appended to the `flutter test` command.
+    description: |-
+      The flags from this input field are appended to the `flutter test` command.
+
+      For example, pass `--reporter expanded` to get more detailed, human-readable test output in the build log (Flutter 3.10+). Do not pass `--file-reporter`; the Step sets it up internally.
 - tests_path_pattern:
   opts:
     title: Test files pattern

--- a/test_executor.go
+++ b/test_executor.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/bitrise-io/go-utils/log"
 )
@@ -23,12 +24,93 @@ type realTestExecutor struct {
 }
 
 func (r realTestExecutor) executeTest(cfg config, additionalParams []string) (bytes.Buffer, bool) {
+	if hasFileReporterArg(additionalParams) {
+		r.interrupt.failWithMessage("Process config: passing --file-reporter in Additional parameters is not supported; the step sets it up internally.")
+		return bytes.Buffer{}, true
+	}
+
+	if r.commandBuilder.supportsFileReporter() {
+		return r.executeTestWithFileReporter(cfg, additionalParams)
+	}
+
+	log.Warnf("`flutter test` does not support --file-reporter (Flutter < 3.10); the log will show the raw machine JSON stream. Upgrade to Flutter 3.10 or newer for human-readable test output.")
+	return r.executeTestLegacy(cfg, additionalParams)
+}
+
+// executeTestWithFileReporter runs `flutter test` with --file-reporter so stdout keeps the
+// normal, human-readable reporter output, then converts the JSON report file to JUnit XML.
+func (r realTestExecutor) executeTestWithFileReporter(cfg config, additionalParams []string) (bytes.Buffer, bool) {
+	jsonReportFile, err := os.CreateTemp("", "flutter_json_test_results_*.json")
+	if err != nil {
+		r.interrupt.failWithMessage("Run: failed to create temporary test report file: %s", err)
+	}
+	jsonReportPath := jsonReportFile.Name()
+	jsonReportFile.Close()
+	defer os.Remove(jsonReportPath)
+
+	testCmd := r.commandBuilder.buildTestCmd(cfg.GenerateCodeCoverageFiles, jsonReportPath, additionalParams)
+	testCmdModel := testCmd.toModel().
+		SetStdout(os.Stdout).
+		SetStderr(os.Stderr).
+		SetDir(cfg.ProjectLocation)
+
+	fmt.Println()
+	log.Donef("$ %s", testCmdModel.PrintableCommandArgs())
+	fmt.Println()
+
+	testExecutionFailed := false
+	if err := testCmd.start(); err != nil {
+		r.interrupt.failWithMessage("Run: test command failed: %s", err)
+	}
+
+	// Don't abort on test failures: we still want to convert and export whatever
+	// results were produced.
+	if err := testCmd.wait(); err != nil {
+		log.Errorf("Run: completing test command failed: %s", err)
+		testExecutionFailed = true
+	}
+
+	// Read back the JSON report for the JUnit conversion and the JSON output export.
+	// A missing/unreadable report (e.g. flutter crashed before writing it, or a mocked
+	// command in unit tests) is not fatal: continue with an empty buffer.
+	var jsonBuffer bytes.Buffer
+	if data, err := os.ReadFile(jsonReportPath); err != nil {
+		log.Warnf("Run: could not read test result JSON (%s): %s", jsonReportPath, err)
+	} else {
+		jsonBuffer.Write(data)
+	}
+
+	junitCmd := r.commandBuilder.buildJunitCmd(cfg, jsonReportPath)
+	junitCmdModel := junitCmd.toModel().
+		SetStdout(os.Stdout).
+		SetStderr(os.Stderr).
+		SetDir(cfg.ProjectLocation)
+
+	fmt.Println()
+	log.Donef("$ %s", junitCmdModel.PrintableCommandArgs())
+	fmt.Println()
+
+	if err := junitCmd.start(); err != nil {
+		r.interrupt.failWithMessage("Run: converting test results to junit format failed: %s", err)
+	}
+
+	if err := junitCmd.wait(); err != nil {
+		r.interrupt.failWithMessage("Run: completing conversion command failed: %s", err)
+	}
+
+	return jsonBuffer, testExecutionFailed
+}
+
+// executeTestLegacy is the pre-3.10 fallback: it pipes `flutter test --machine` stdout
+// straight into tojunit. The build log therefore shows the raw machine JSON stream
+// (the step's original behavior).
+func (r realTestExecutor) executeTestLegacy(cfg config, additionalParams []string) (bytes.Buffer, bool) {
 	var jsonBuffer bytes.Buffer
 	pr, pw := io.Pipe()
 	testCmdWriter := io.MultiWriter(pw, &jsonBuffer)
 
-	testCmd := r.commandBuilder.buildTestCmd(cfg.GenerateCodeCoverageFiles, additionalParams)
-	junitCmd := r.commandBuilder.buildJunitCmd(cfg)
+	testCmd := r.commandBuilder.buildLegacyTestCmd(cfg.GenerateCodeCoverageFiles, additionalParams)
+	junitCmd := r.commandBuilder.buildLegacyJunitCmd(cfg)
 
 	testExecutionFailed := false
 
@@ -77,6 +159,19 @@ func (r realTestExecutor) executeTest(cfg config, additionalParams []string) (by
 	}
 
 	return jsonBuffer, testExecutionFailed
+}
+
+// hasFileReporterArg reports whether the user passed their own --file-reporter flag
+// (either "--file-reporter=<value>" or "--file-reporter <value>"). The step manages
+// --file-reporter itself, so a user-supplied one is rejected.
+func hasFileReporterArg(params []string) bool {
+	const flag = "--file-reporter"
+	for _, p := range params {
+		if p == flag || strings.HasPrefix(p, flag+"=") {
+			return true
+		}
+	}
+	return false
 }
 
 func (r realTestExecutor) exportTestResults(cfg config, jsonBuffer bytes.Buffer) {

--- a/vendor/github.com/bmatcuk/doublestar/v3/go.mod
+++ b/vendor/github.com/bmatcuk/doublestar/v3/go.mod
@@ -1,3 +1,0 @@
-module github.com/bmatcuk/doublestar/v3
-
-go 1.12

--- a/vendor/gopkg.in/yaml.v3/go.mod
+++ b/vendor/gopkg.in/yaml.v3/go.mod
@@ -1,5 +1,0 @@
-module "gopkg.in/yaml.v3"
-
-require (
-	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
-)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,10 +1,10 @@
 # github.com/bitrise-io/go-steputils v1.0.1
-## explicit
+## explicit; go 1.15
 github.com/bitrise-io/go-steputils/stepconf
 github.com/bitrise-io/go-steputils/testresultexport
 github.com/bitrise-io/go-steputils/tools
 # github.com/bitrise-io/go-utils v1.0.1
-## explicit
+## explicit; go 1.13
 github.com/bitrise-io/go-utils/colorstring
 github.com/bitrise-io/go-utils/command
 github.com/bitrise-io/go-utils/errorutil
@@ -14,17 +14,20 @@ github.com/bitrise-io/go-utils/parseutil
 github.com/bitrise-io/go-utils/pathutil
 github.com/bitrise-io/go-utils/pointers
 # github.com/bmatcuk/doublestar/v3 v3.0.0
-## explicit
+## explicit; go 1.12
 github.com/bmatcuk/doublestar/v3
 # github.com/davecgh/go-spew v1.1.1
+## explicit
 github.com/davecgh/go-spew/spew
 # github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 ## explicit
 github.com/kballard/go-shellquote
 # github.com/pmezard/go-difflib v1.0.0
+## explicit
 github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.7.0
-## explicit
+## explicit; go 1.13
 github.com/stretchr/testify/assert
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/) (`1.0.3` → `1.1.0`).

### Context

The Flutter Test step never showed human-readable test output. It ran `flutter test --machine`, which forces Flutter's internal JSON reporter and silently overrides any user-supplied `--reporter`, then piped that machine JSON into `tojunit`. As a result the build log only showed `tojunit`'s minimal output — no "All tests passed" summary or test counts — and `--reporter expanded` in **Additional parameters** had no effect. A user had to add a separate script step just to confirm tests were running.

Resolves: https://bitrise.atlassian.net/browse/SSW-3088

### Changes

- Use `flutter test --file-reporter=json:<file>` instead of `--machine`: the machine-readable JSON is written to a file while stdout keeps the normal, human-readable reporter (Flutter auto-selects `expanded` on CI / `github` on GitHub Actions). The file is then fed to `tojunit --input`.
- `--file-reporter` was added in Flutter 3.10, so `supportsFileReporter()` probes `flutter test --help` and falls back to the original `--machine` pipe on older Flutter — no regression.
- Reject a user-supplied `--file-reporter` in **Additional parameters** (the step manages it internally).
- Bump the Go directive to 1.18 (`go mod tidy` / `go mod vendor`).
- e2e: install Flutter via Bitrise's built-in mise `tools` field instead of the `flutter-installer` step, and add a workflow that exercises the new `--file-reporter` path on Flutter 3.10+.
- Update `step.yml` and `README.md`.

> **Companion change:** the modern-path e2e workflow needs a Dart-3-compatible project. The shared sample app (`bitrise-io/Bitrise-Flutter-Sample`) is pinned to Dart < 3.0, so a new [`dart-3` branch](https://github.com/bitrise-io/Bitrise-Flutter-Sample/tree/dart-3) was added (null-safety migration) — `main` is left untouched so existing Dart-2 consumers keep working.

### Investigation details

- The `--machine` pipe (and its recent deadlock fix, #44) existed only to stream JSON into `tojunit`; `--file-reporter` + `tojunit --input` removes the need for the pipe on modern Flutter.
- `--file-reporter` landed in `flutter/flutter` commit `ebbc94bc` (2023-02-21), first shipping in stable Flutter 3.10.0. Verified locally that 3.7.1 rejects it (`Could not find an option named "file-reporter"`) and 3.32.1 accepts it.
- `tojunit --input` has existed since `junitreport`'s first release (2016); the step always installs the latest via `dart pub global activate`, so there is no dependency-recency risk.
- Verified end to end: the new path (Flutter 3.32.1, sample `dart-3` branch) prints readable output plus valid JUnit XML and a non-empty JSON report; the legacy fallback (3.7.1, `main`) is unchanged. Both e2e paths pass locally, including the coverage variant. (Note: the e2e workflows share `_tmp` in one working copy, so they must be run sequentially, not concurrently.)

### Decisions

- **Capability-detect + fallback** rather than requiring Flutter 3.10+, so users on older Flutter are not broken → ships as a MINOR release.
- **Do not inject `--reporter`**; let Flutter pick the CI-appropriate reporter and let users override it via Additional parameters.
- **Fail fast** on a user-provided `--file-reporter` rather than trying to parse/honor it.
- **New `dart-3` sample branch** instead of migrating `main`, so the modern-path e2e can reuse `_common` without breaking other consumers of the shared sample.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
